### PR TITLE
Pandar64 driver ready for Bloom release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+dist: trusty
+language: generic
+compiler:
+  - gcc
+env:
+  matrix:
+    - ROS_DISTRO="kinetic" ROS_REPO=ros CATKIN_CONFIG="-DCMAKE_BUILD_TYPE=Release" DOCKER_BASE_IMAGE=ros:kinetic-perception
+    - ROS_DISTRO="melodic" ROS_REPO=ros CATKIN_CONFIG="-DCMAKE_BUILD_TYPE=Release" DOCKER_BASE_IMAGE=ros:melodic-perception
+
+install:
+  git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  source .ci_config/travis.sh
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,35 +4,101 @@ project(hesai_lidar)
 # Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++11)
 
-
-
-find_package(catkin REQUIRED COMPONENTS
-  cv_bridge
-  image_transport
-  sensor_msgs
-)
-find_package( Boost REQUIRED )
+find_package(Boost REQUIRED )
 find_package(PCL REQUIRED)
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
+find_path(YAML_CPP_INCLUDE_DIR NAMES yaml_cpp.h PATHS ${YAML_CPP_INCLUDE_DIRS})
+find_library(YAML_CPP_LIBRARY NAMES YAML_CPP PATHS ${YAML_CPP_LIBRARIES})
+
+find_package(catkin REQUIRED COMPONENTS
+    roscpp
+    roslib
+    std_msgs
+    sensor_msgs
+    message_runtime
+    image_transport
+    pcl_conversions
+    cv_bridge
+)
 catkin_package()
 
-add_subdirectory(src/PandarGeneral)
+###PandarGeneralRaw
+add_library(PandarGeneral
+    src/PandarGeneral/src/PandarGeneralRaw/src/input.cc
+    src/PandarGeneral/src/PandarGeneralRaw/src/pandarGeneral_internal.cc
+    src/PandarGeneral/src/PandarGeneralRaw/src/pandarGeneral.cc
+)
+target_include_directories(PandarGeneral PRIVATE
+    src/PandarGeneral/src/PandarGeneralRaw/include
+    src/PandarGeneral/src/PandarGeneralRaw/
+    ${Boost_INCLUDE_DIRS}
+    ${PCL_INCLUDE_DIRS}
+    ${catkin_INCLUDE_DIRS}
+)
+target_link_libraries(PandarGeneral
+    ${Boost_LIBRARIES}
+    ${PCL_IO_LIBRARIES}
+)
+
+###PandarGeneralSDK
+add_library(PandarGeneralSDK SHARED
+    src/PandarGeneral/src/pandarGeneral_sdk.cc
+    src/PandarGeneral/src/tcp_command_client.c
+    src/PandarGeneral/src/util.c
+)
+target_include_directories(PandarGeneralSDK PRIVATE
+    src/PandarGeneral/
+    src/PandarGeneral/include/
+    src/PandarGeneral/src/PandarGeneralRaw/include
+    ${Boost_INCLUDE_DIRS}
+    ${PCL_INCLUDE_DIRS}
+    ${OpenCV_INCLUDE_DIRS}
+    ${YAML_CPP_INCLUDE_DIRS}
+    ${catkin_INCLUDE_DIRS}
+)
+
+target_link_libraries(PandarGeneralSDK 
+    PandarGeneral
+    ${Boost_LIBRARIES}
+    ${PCL_IO_LIBRARIES}
+    ${YAML_CPP_LIBRARIES}
+    ${catkin_LIBRARIES}
+)
+
+###hesai node
 add_executable(hesai_lidar_node 
-	src/main.cc
+    src/main.cc
 )
 
-include_directories(
-  src/PandarGeneral/include
-  src/PandarGeneral/src/PandarGeneralRaw/include
-  ${PCL_INCLUDE_DIRS}
-  ${catkin_INCLUDE_DIRS}
-  ${Boost_INCLUDE_DIRS}
+target_include_directories(hesai_lidar_node PRIVATE
+    src/PandarGeneral/include
+    src/PandarGeneral/src/PandarGeneralRaw/include
+    ${PCL_INCLUDE_DIRS}
+    ${catkin_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
 )
-
-
 
 target_link_libraries(hesai_lidar_node 
-	${catkin_LIBRARIES}
-  ${PCL_IO_LIBRARIES}
-  PandarGeneralSDK
+    ${catkin_LIBRARIES}
+    ${PCL_IO_LIBRARIES}
+    PandarGeneralSDK
+)
+
+install(TARGETS
+    hesai_lidar_node
+    PandarGeneral
+    PandarGeneralSDK
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch/
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)
+
+install(DIRECTORY config/
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/config
 )

--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,13 @@
-BSD 3-Clause License
+Copyright [2018] [Hesai Technology]
 
-Copyright (c) 2018, HesaiTechnology
-All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+    http://www.apache.org/licenses/LICENSE-2.0
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.xml
+++ b/package.xml
@@ -1,63 +1,23 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>hesai_lidar</name>
   <version>0.0.0</version>
-  <description>The hesai_lidar package</description>
+  <description>
+    The hesai_lidar package includes the driver for the Heisai Pandar64 LiDAR sensor.
+  </description>
+  <maintainer email="wuxiaozhou@hesaitech.com">hesaiwuxiaozhou</maintainer>
+  <license>Apache 2</license>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="yy@todo.todo">yy</maintainer>
-
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
-
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/pandora_camera</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *_depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>image_transport</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>pandar_msgs</build_depend>
-  <run_depend>pandar_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>  
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>image_transport</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>std_msgs</run_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
+  <depend>roscpp</depend>
+  <depend>roslib</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>message_runtime</depend>
+  <depend>yaml-cpp</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>image_transport</depend>
+  <depend>pcl_conversions</depend>
+  <depend>cv_bridge</depend>
 </package>

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/amc-nu/HesaiLidar_Pandar64_ros.svg?branch=master)](https://travis-ci.org/amc-nu/HesaiLidar_Pandar64_ros)
+
 # Hesai Pandar40P 
 
 This repository includes the ROS Driver for the Pandar64 LiDAR sensor manufactured by Hesai Technology.

--- a/readme.md
+++ b/readme.md
@@ -1,36 +1,58 @@
-## Dependency
-```
-1. ROS
-2. sudo apt install libpcap-dev libyaml-cpp-dev
-```
+# Hesai Pandar40P 
 
-## Build
-```
-mkdir -p rosworkspace/src ; cd rosworkspace/src
-git clone https://github.com/HesaiTechnology/HesaiLidar_Pandar64_ros.git --recursive
-cd ../
-catkin_make
-source ./devel/setup.sh
-```
+This repository includes the ROS Driver for the Pandar64 LiDAR sensor manufactured by Hesai Technology.
 
-## Run
-### Pandar64
-```
-roslaunch hesai_lidar hesai_lidar64.launch
-```
 
-There is one node of Hesai Lidar ROS
-```
-/pandar_points
-```
+## How to Build
 
-## Parameters:
-```
-	<arg name="server_ip" default="192.168.1.201"/> lidar's ip
-	<arg name="lidar_recv_port"  default="2368"/>   lidar's port
-	<arg name="gps_port"  default="10110"/>         gps's port
-	<arg name="start_angle"  default="0"/>          lidar's start angle
-
-  ......
+### Install `catkin_tools`
 
 ```
+$ sudo apt-get update
+$ sudo apt-get install python-catkin-tools
+```
+
+### Compile
+
+1. Create ROS Workspace. i.e. `rosworkspace`
+```
+$ mkdir -p rosworkspace/src
+$ cd rosworkspace/src
+```
+
+2. Clone recursively this repository.
+3. Install required dependencies with the help of `rosdep` 
+```
+$ cd ..
+$ rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO 
+```
+4. Compile
+```
+$ catkin config --install
+$ catkin build --force-cmake
+```
+
+## How to Launch
+
+1. While in the `rosworkspace` directory.
+```
+$ source install/setup.bash
+$ roslaunch hesai_lidar hesai_lidar64.launch
+```
+2. The driver will publish a PointCloud message in the topic.
+```
+/points_raw
+```
+3. Open Rviz and add display by topic.
+4. Change fixed frame to `pandar`.
+
+LiDAR default IP address is 192.168.1.201
+
+## Some of the available parameters in the Launch file
+
+|Parameter | Default Value|
+|---------|---------------|
+|lidar_recv_port |2368|
+|gps_recv_port  |10110|
+|start_angle |0|
+

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/amc-nu/HesaiLidar_Pandar64_ros.svg?branch=master)](https://travis-ci.org/amc-nu/HesaiLidar_Pandar64_ros)
 
-# Hesai Pandar40P 
+# Hesai Pandar64
 
 This repository includes the ROS Driver for the Pandar64 LiDAR sensor manufactured by Hesai Technology.
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -14,7 +14,7 @@ class HesaiLidarClient
 public:
   HesaiLidarClient(ros::NodeHandle node, ros::NodeHandle nh)
   {
-    lidarPublisher = node.advertise<sensor_msgs::PointCloud2>("point_raw", 10);
+    lidarPublisher = node.advertise<sensor_msgs::PointCloud2>("points_raw", 10);
 
     string serverIp;
     int serverPort;


### PR DESCRIPTION
The package's `CMakeLists.txt`, and its `package.xml` files include some issues that limit its Bloom release:
* Incorrect Install commands.
* Missing dependencies.
* Incorrect building order.

This PR:
* Fixes the mentioned issues,
* Adds industrial_ci support: [![Build Status](https://travis-ci.org/amc-nu/HesaiLidar_Pandar64_ros.svg?branch=master)](https://travis-ci.org/amc-nu/HesaiLidar_Pandar64_ros)
* Improves the README file for the users,
* Updates the repository license to match the source code.

Merging this PR will:
* Allow the automatic installation of the dependencies using `rosdep` (for source builds).
* Help verify that new pull requests get verified in a clean environment using docker. (if TravisCI is enabled by the mainteners).
* Ease the quick deployment of this package to the ROS repositories using Bloom.

In a similar fashion to https://github.com/HesaiTechnology/Pandar40p_ros/pull/3

We *strongly* recommend to release the package to ROS repositories using [Bloom](http://wiki.ros.org/bloom/Tutorials/FirstTimeRelease) for at least ROS Melodic and Kinetic. In this way, customers will be able to easily install the driver for the Pandar LiDAR using `apt` in their ROS environment.

Please let us know if we there is anything we can help to get this merged and released. 